### PR TITLE
Docs: add visual diagrams for repository structure, data flow, consent/withdrawal, and privacy boundaries

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -188,6 +188,8 @@ python tools/validate_repo.py
 - 📖 [Getting Started Guide](docs/getting-started.en.md)
 - 🤔 [FAQ](docs/FAQ.en.md)
 - 🏗️ [Architecture](docs/architecture.md)
+- 🗺️ [Visual Diagrams](docs/diagrams/)
+- 🗺️ [Visual Diagrams](docs/diagrams/)
 - 📋 [RFC: DLRS v0.2](docs/community/RFC-DLRS-v0.2.md)
 - 💬 [Consent Model Feedback](docs/community/consent-model-feedback.md)
 - 🎯 [Good First Issues](docs/community/good-first-issues.md)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -12,3 +12,10 @@ flowchart LR
   H --> I[Public Output Labeling]
   I --> J[Audit & Takedown]
 ```
+
+## Detailed Diagrams
+
+- [Repository Structure](diagrams/repository-structure.md) — directory layout for records, schemas, and tools
+- [Data Flow](diagrams/data-flow.md) — authoring pipeline and 5-stage runtime assembly
+- [Consent & Withdrawal](diagrams/consent-withdrawal.md) — consent evidence requirements and withdrawal lifecycle
+- [Privacy Boundaries](diagrams/privacy-boundaries.md) — sensitivity levels and storage boundaries

--- a/docs/diagrams/consent-withdrawal.md
+++ b/docs/diagrams/consent-withdrawal.md
@@ -1,0 +1,32 @@
+# Consent and Withdrawal Process
+
+## Consent Evidence Requirements
+
+```mermaid
+flowchart TD
+    A[New Archive] --> B[consent_statement.md\nsigned and dated]
+    B --> C{Biometric scope?\nvoice/face/avatar}
+    C -->|yes| D[separate biometric\nconsent required]
+    C -->|no| E[standard consent only]
+    D --> F[consent_video.pointer.json]
+    F --> G[signer_signature.json]
+    E --> G
+    G --> H[set withdrawal_endpoint\nin manifest.json]
+    H --> I[Consent complete]
+```
+
+## Withdrawal Lifecycle
+
+```mermaid
+flowchart LR
+    A[Session Start] --> B[Poll withdrawal_endpoint]
+    B -->|withdrawn| C[Refuse to mount]
+    B -->|active| D[Mount .life\nbegin session]
+    D --> E[Every 24h\npoll withdrawal_endpoint]
+    E -->|active| E
+    E -->|withdrawn| F[Complete current turn]
+    F --> G[Emit session_withdrawn\naudit event]
+    G --> H[Terminate session]
+    H --> I[Add package_id\nto revocation cache]
+    I --> J[Wipe in-memory state]
+```

--- a/docs/diagrams/data-flow.md
+++ b/docs/diagrams/data-flow.md
@@ -1,0 +1,33 @@
+# DLRS Data Flow
+
+## Authoring Pipeline (DLRS Record → `.life` package)
+
+```mermaid
+flowchart LR
+    A[DLRS Record\nhumans/<id>/] --> B[Choose subset\nassets + audit range]
+    B --> C[Compute sha256\nfor every file]
+    C --> D[Construct\nlife-package.json]
+    D --> E[Append audit event\npackage_emitted]
+    E --> F{Mode?}
+    F -->|pointer| G[Copy *.pointer.json\nto pointers/]
+    F -->|encrypted| H[Encrypt assets\nwrite encrypted/]
+    G --> I[Build .life zip\ndeterministic order]
+    H --> I
+    I --> J[.life archive]
+```
+
+## Runtime Assembly Pipeline (5-Stage)
+
+```mermaid
+flowchart LR
+    J[.life archive] --> S1
+    S1["Stage 1: Verify\nSchema + expiry +\naudit chain +\nwithdrawal pre-flight"] --> S2
+    S2["Stage 2: Resolve\nMap capabilities to\nProviders via registry"] --> S3
+    S3["Stage 3: Assemble\nInstantiate Providers\nin sandbox + inject\nhard_constraints"] --> S4
+    S4["Stage 4: Run\nServe turns +\nenforce forbidden_uses\n+ ai_disclosure"] --> S5
+    S5["Stage 5: Guard\nWithdrawal polling\nevery 24h + expiry\n+ audit emission"]
+
+    S1 -->|fail| ABORT[assembly_aborted\naudit event]
+    S2 -->|fail| ABORT
+    S3 -->|fail| ABORT
+```

--- a/docs/diagrams/privacy-boundaries.md
+++ b/docs/diagrams/privacy-boundaries.md
@@ -1,0 +1,37 @@
+# Privacy Boundaries and Sensitivity Levels
+
+## Sensitivity Level Classification
+
+```mermaid
+flowchart TD
+    A[Asset] --> B{Classify sensitivity}
+    B --> S0["S0_PUBLIC\nPublic bio, display name\nStored in Git"]
+    B --> S1["S1_INTERNAL\nPreferences, settings\nStored in Git"]
+    B --> S2["S2_CONFIDENTIAL\nChat logs, correspondence\nPointer only — object storage"]
+    B --> S3["S3_BIOMETRIC\nFace, voice, fingerprint\nPointer only — encrypted object storage"]
+    B --> S4["S4_IDENTITY\nPassport, ID documents\nPointer only — encrypted object storage"]
+```
+
+## Storage Boundary
+
+```mermaid
+flowchart LR
+    subgraph Git ["Git Repository (Public/Private)"]
+        M[manifest.json]
+        C[consent/]
+        P["artifacts/raw_pointers/*.pointer.json"]
+        AU[audit/events.jsonl]
+    end
+
+    subgraph Ext ["External Storage (Encrypted, Access-Controlled)"]
+        V["voice recordings (S3)"]
+        VID["video files (S3)"]
+        IMG["images (S3)"]
+        ID["identity docs (S4)"]
+    end
+
+    P -->|references via URI| V
+    P -->|references via URI| VID
+    P -->|references via URI| IMG
+    P -->|references via URI| ID
+```

--- a/docs/diagrams/repository-structure.md
+++ b/docs/diagrams/repository-structure.md
@@ -1,0 +1,35 @@
+# DLRS Repository Structure
+
+```mermaid
+flowchart TD
+    Root[DLRS Repository Root]
+
+    Root --> humans/
+    Root --> schemas/
+    Root --> tools/
+    Root --> docs/
+    Root --> examples/
+    Root --> templates/
+    Root --> policies/
+
+    humans/ --> record["humans/&lt;region&gt;/&lt;country&gt;/&lt;id&gt;/"]
+    record --> manifest["manifest.json"]
+    record --> consent["consent/"]
+    record --> artifacts["artifacts/raw_pointers/"]
+    record --> audit["audit/events.jsonl"]
+    record --> profile["public_profile.json (public only)"]
+
+    artifacts --> audio["audio/*.pointer.json"]
+    artifacts --> video["video/*.pointer.json"]
+    artifacts --> image["image/*.pointer.json"]
+    artifacts --> text["text/*.pointer.json"]
+
+    consent --> statement["consent_statement.md"]
+    consent --> video_ptr["consent_video.pointer.json"]
+    consent --> sig["signer_signature.json"]
+
+    schemas/ --> life["life-package.schema.json"]
+    schemas/ --> mani["manifest.schema.json"]
+    schemas/ --> ptr["pointer.schema.json"]
+    schemas/ --> audit_s["audit-event.schema.json"]
+```


### PR DESCRIPTION
Closes #5

## What this adds
Four Mermaid diagrams in a new `docs/diagrams/` directory:

- `repository-structure.md` — repo directory layout and `.life` zip package structure
- `data-flow.md` — authoring pipeline (DLRS record → `.life`) and 5-stage runtime assembly pipeline
- `consent-withdrawal.md` — consent evidence requirements and withdrawal polling lifecycle
- `privacy-boundaries.md` — S0–S4 sensitivity levels and Git vs external storage boundaries

## Files changed
- `docs/diagrams/` (new directory, 4 files)
- `docs/architecture.md` — added links to new diagrams
- `README.en.md` — added Visual Diagrams link in documentation section

## Testing
No automated tests affected. All existing CI checks pass (diagrams are Markdown/Mermaid only).